### PR TITLE
Added -t flag to give more control over HTTP concurrency

### DIFF
--- a/main.go
+++ b/main.go
@@ -22,7 +22,7 @@ func main() {
 	flag.StringVar(&o.FilterResponseCode, "hc", "", "The response code(s) to hide (e.g. -hc 302 or -hc 404,400).")
 	flag.StringVar(&o.FilterResponseSize, "hs", "", "The response size(s) to hide (e.g. -hs 4096 or -hs 4096,1024).")
 	flag.BoolVar(&o.Verbose, "v", false, "Verbose output")
-	flag.IntVar(&o.Threads, "t", 1, "Concurrent requests")
+	flag.IntVar(&o.Threads, "t", 30, "Concurrent requests")
 
 	flag.Usage = gobypasser.Usage
 	flag.Parse()

--- a/main.go
+++ b/main.go
@@ -22,6 +22,7 @@ func main() {
 	flag.StringVar(&o.FilterResponseCode, "hc", "", "The response code(s) to hide (e.g. -hc 302 or -hc 404,400).")
 	flag.StringVar(&o.FilterResponseSize, "hs", "", "The response size(s) to hide (e.g. -hs 4096 or -hs 4096,1024).")
 	flag.BoolVar(&o.Verbose, "v", false, "Verbose output")
+	flag.IntVar(&o.Threads, "t", 1, "Concurrent requests")
 
 	flag.Usage = gobypasser.Usage
 	flag.Parse()

--- a/pkg/gobypasser/help.go
+++ b/pkg/gobypasser/help.go
@@ -146,5 +146,9 @@ func VerifyOptions(o *Options) (bool, string) {
 		o.ParsedFilterResponseSize = append(o.ParsedFilterResponseSize, strings.Split(o.FilterResponseSize, ",")...)
 	}
 
+	if (o.Threads < 1) || (o.Threads > 30) {
+		return false, fmt.Sprintln("Concurrent threads must be between 1 - 30")
+	}
+
 	return true, ""
 }

--- a/pkg/gobypasser/help.go
+++ b/pkg/gobypasser/help.go
@@ -146,8 +146,8 @@ func VerifyOptions(o *Options) (bool, string) {
 		o.ParsedFilterResponseSize = append(o.ParsedFilterResponseSize, strings.Split(o.FilterResponseSize, ",")...)
 	}
 
-	if (o.Threads < 1) || (o.Threads > 30) {
-		return false, fmt.Sprintln("Concurrent threads must be between 1 - 30")
+	if (o.Threads < 1) || (o.Threads > 200) {
+		return false, fmt.Sprintln("Concurrent threads must be between 1 - 200")
 	}
 
 	return true, ""

--- a/pkg/gobypasser/options.go
+++ b/pkg/gobypasser/options.go
@@ -24,6 +24,8 @@ type Options struct {
 	TimeoutRequests        int
 	TotalRequestsFailed    int
 	TotalRequestsSucceeded int
+
+	Threads int
 }
 
 func SetDefaultOptions(o *Options) {
@@ -49,4 +51,5 @@ func SetDefaultOptions(o *Options) {
 	o.TimeoutRequests = 0
 	o.TotalRequestsSucceeded = 0
 	o.TotalRequestsFailed = 0
+
 }

--- a/pkg/gobypasser/options.go
+++ b/pkg/gobypasser/options.go
@@ -52,4 +52,6 @@ func SetDefaultOptions(o *Options) {
 	o.TotalRequestsSucceeded = 0
 	o.TotalRequestsFailed = 0
 
+	o.Threads = 30
+
 }


### PR DESCRIPTION
Added -t flag to give more control over HTTP concurrency

After some testing 30 threads seems like a nice spot for the default setting, added verification to ensure "-t" value sits between 1 - 200.

 